### PR TITLE
GEOPY-1432: Use name of drillhole first in export name

### DIFF
--- a/las_geoh5/export_las.py
+++ b/las_geoh5/export_las.py
@@ -161,7 +161,7 @@ def write_curves(
         else:
             subpath = basepath
 
-        filename = f"{group.name}_{drillhole.name}.las"
+        filename = f"{drillhole.name}_{group.name}.las"
         with open(
             subpath / filename, "a", encoding="utf8"
         ) as io:  # pylint: disable=invalid-name
@@ -194,7 +194,7 @@ def write_survey(
         if not basepath.exists():
             basepath.mkdir()
 
-    filename = f"survey_{drillhole.name}.las"
+    filename = f"{drillhole.name}_survey.las"
     with open(
         basepath / filename, "a", encoding="utf8"
     ) as io:  # pylint: disable=invalid-name

--- a/tests/geoh5_to_las_test.py
+++ b/tests/geoh5_to_las_test.py
@@ -109,7 +109,7 @@ def test_create_or_append_drillhole(tmp_path):
         write_curves(drillhole_a, tmp_path, use_directories=False)
 
         file = lasio.read(
-            Path(tmp_path / f"{drillhole_a.property_groups[0].name}_dh1.las"),
+            Path(tmp_path / f"dh1_{drillhole_a.property_groups[0].name}.las"),
             mnemonic_case="preserve",
         )
         assert "DEPTH" in [k.mnemonic for k in file.curves]
@@ -126,7 +126,7 @@ def test_create_or_append_drillhole(tmp_path):
         assert drillhole.get_data("my_new_data")
 
         file = lasio.read(
-            Path(tmp_path / f"{drillhole_a.property_groups[0].name}_dh1.las"),
+            Path(tmp_path / f"dh1_{drillhole_a.property_groups[0].name}.las"),
             mnemonic_case="preserve",
         )
         file.well["X"] = 10.0
@@ -181,9 +181,9 @@ def test_add_survey(tmp_path):
         drillhole_to_las(drillhole_a, tmp_path, use_directories=False)
         basepath = Path(tmp_path)
         data = lasio.read(
-            Path(basepath / f"{drillhole_a.property_groups[0].name}_dh1.las")
+            Path(basepath / f"dh1_{drillhole_a.property_groups[0].name}.las")
         )
-        survey = Path(basepath / "survey_dh1.las")
+        survey = Path(basepath / "dh1_survey.las")
         las_to_drillhole(
             data,
             drillhole_group,


### PR DESCRIPTION
**GEOPY-1432 - Use name of drillhole first in export name**
