### PR TITLE
GEOPY-2998: Update docs with release notes from GA 4.8 release

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -18,7 +18,7 @@ Release 0.3.1 (2025-06-18)
 --------------------------
 
 - Build conda package faster with rattler-build
-- For pypi, use dedicated package.rst as long description (readme field) instead of README.rst
+- For PyPI, use dedicated package.rst as long description (readme field) instead of README.rst
 - Relock on latest git dev revisions
 - Re-versioned
 - Adjust ui.json

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,6 +1,42 @@
 Release Notes
 =============
 
+Release 0.3.3 (2026-07-04)
+--------------------------
+
+- GEOPY-1800: Remove and fix pylint and mypy disables
+- GEOPY-2741: Update to Python 3.12
+
+Release 0.3.2 (2025-12-18)
+--------------------------
+
+- GEOPY-2400: Review changes made to ui.json coming from release
+- GEOPY-2464: Remove depth name from import-files ui.json
+
+
+Release 0.3.1 (2025-06-18)
+--------------------------
+
+- DEVOPS-635: Build conda package faster with rattler-build
+- GEOPY-1862: For pypi, use dedicated package.rst as long description (readme field) instead of README.rst
+- GEOPY-2049: Relock on latest git dev revisions
+- GEOPY-2049: Re-versioned
+- GEOPY-2142: Adjust ui.json
+- GEOPY-2230: Update ui.json file as per latest adjustment in Analyst
+
+
+Release 0.3.0 (2025-02-07)
+--------------------------
+
+- GEOPY-1512: Clean out "workspace" field in UI.json
+- GEOPY-1546: Improve tooltips and label in title for MNEM field for collar
+- GEOPY-1781: Fixes for using geoh5 v0.10.0
+- GEOPY-1753: LAS importer - vertical colocation
+- GEOPY-1817: Check that utf-8 characters are supported
+- GEOPY-1860: Do not include top level files in wheels
+
+
+
 Release 0.2.0 (2024-04-15)
 --------------------------
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -40,16 +40,16 @@ Release 0.3.0 (2025-02-07)
 Release 0.2.0 (2024-04-15)
 --------------------------
 
-- Add Documentation.
-- Drillhole name first in exported LAS files.
-- Suffix exported .las files with property group name.
-- Move all parameters in import ui.json to main tab.
+- Add Documentation
+- Drillhole name first in exported LAS files
+- Suffix exported .las files with property group name
+- Move all parameters in import ui.json to main tab
 - Expose collocation tolerance in import ui.json file
 - Improve logging
-- Increment property group and data names for existing non-collocated objects.
+- Increment property group and data names for existing non-collocated objects
 
 Release 0.1.0 (2023-11-02)
 --------------------------
 
-- Introduce a generalized .las importer.
-- Introduce import/export in and out of directory structure.
+- Introduce a generalized .las importer
+- Introduce import/export in and out of directory structure

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,52 +4,52 @@ Release Notes
 Release 0.3.3 (2026-07-04)
 --------------------------
 
-- GEOPY-1800: Remove and fix pylint and mypy disables
-- GEOPY-2741: Update to Python 3.12
+- Remove and fix pylint and mypy disables
+- Update to Python 3.12
 
 Release 0.3.2 (2025-12-18)
 --------------------------
 
-- GEOPY-2400: Review changes made to ui.json coming from release
-- GEOPY-2464: Remove depth name from import-files ui.json
+- Review changes made to ui.json coming from release
+- Remove depth name from import-files ui.json
 
 
 Release 0.3.1 (2025-06-18)
 --------------------------
 
-- DEVOPS-635: Build conda package faster with rattler-build
-- GEOPY-1862: For pypi, use dedicated package.rst as long description (readme field) instead of README.rst
-- GEOPY-2049: Relock on latest git dev revisions
-- GEOPY-2049: Re-versioned
-- GEOPY-2142: Adjust ui.json
-- GEOPY-2230: Update ui.json file as per latest adjustment in Analyst
+- Build conda package faster with rattler-build
+- For pypi, use dedicated package.rst as long description (readme field) instead of README.rst
+- Relock on latest git dev revisions
+- Re-versioned
+- Adjust ui.json
+- Update ui.json file as per latest adjustment in Analyst
 
 
 Release 0.3.0 (2025-02-07)
 --------------------------
 
-- GEOPY-1512: Clean out "workspace" field in UI.json
-- GEOPY-1546: Improve tooltips and label in title for MNEM field for collar
-- GEOPY-1781: Fixes for using geoh5 v0.10.0
-- GEOPY-1753: LAS importer - vertical colocation
-- GEOPY-1817: Check that utf-8 characters are supported
-- GEOPY-1860: Do not include top level files in wheels
+- Clean out "workspace" field in UI.json
+- Improve tooltips and label in title for MNEM field for collar
+- Fixes for using geoh5 v0.10.0
+- LAS importer - vertical colocation
+- Check that utf-8 characters are supported
+- Do not include top level files in wheels
 
 
 
 Release 0.2.0 (2024-04-15)
 --------------------------
 
-- GEOPY-1420: Add Documentation.
-- GEOPY-1432: Drillhole name first in exported LAS files.
-- GEOPY-1414: Suffix exported .las files with property group name.
-- GEOPY-1413: Move all parameters in import ui.json to main tab.
-- GEOPY-1320: Expose collocation tolerance in import ui.json file
-- GEOPY-1324: Improve logging
-- GEOPY-1147: Increment property group and data names for existing non-collocated objects.
+- Add Documentation.
+- Drillhole name first in exported LAS files.
+- Suffix exported .las files with property group name.
+- Move all parameters in import ui.json to main tab.
+- Expose collocation tolerance in import ui.json file
+- Improve logging
+- Increment property group and data names for existing non-collocated objects.
 
 Release 0.1.0 (2023-11-02)
 --------------------------
 
-- GEOPY-1046: Introduce a generalized .las importer.
-- GEOPY-1008: Introduce import/export in and out of directory structure.
+- Introduce a generalized .las importer.
+- Introduce import/export in and out of directory structure.


### PR DESCRIPTION
**GEOPY-2998 - Update docs with release notes from GA 4.8 release**
